### PR TITLE
Restrict frontend access to Netlify API token via RLS

### DIFF
--- a/supabase/001_initial_schema.sql
+++ b/supabase/001_initial_schema.sql
@@ -189,8 +189,6 @@ create trigger set_updated_at
   execute function public.handle_updated_at();
 
 -- ─── User settings (Netlify API token, etc.) ────────────────
--- NOTE: Sensitive tokens should ideally be stored in a private schema
--- if they are only needed by backend/edge functions.
 create table public.user_settings (
   user_id             uuid primary key references auth.users(id) on delete cascade,
   netlify_api_token   text,                     -- encrypted at rest by Supabase
@@ -200,8 +198,6 @@ create table public.user_settings (
 
 alter table public.user_settings enable row level security;
 
--- Only allow reading settings if absolutely necessary for the frontend.
--- If the API token is only for backend use, consider moving it to a private schema.
 create policy "Users can read own settings"
   on public.user_settings for select
   using (auth.uid() = user_id);
@@ -213,6 +209,12 @@ create policy "Users can upsert own settings"
 create policy "Users can update own settings"
   on public.user_settings for update
   using (auth.uid() = user_id);
+
+-- Prevent the frontend client from reading the API token back after it is saved.
+-- The authenticated role can write the token but not select it; server-side
+-- edge functions that run under the service_role key are not subject to this
+-- column-level restriction and can still read the token for API calls.
+revoke select (netlify_api_token) on public.user_settings from authenticated;
 
 create trigger set_settings_updated_at
   before update on public.user_settings


### PR DESCRIPTION
## Summary
Improved security posture for sensitive API tokens by implementing column-level access control. The frontend can now write the Netlify API token but cannot read it back, while server-side edge functions retain full access.

## Key Changes
- Removed outdated comments about moving sensitive tokens to a private schema
- Added column-level RLS restriction using `revoke select (netlify_api_token) from authenticated`
- Added explanatory comment documenting the security model: authenticated clients can write tokens but not read them, while service_role functions can still access tokens for backend operations

## Implementation Details
- The `revoke` statement prevents the `authenticated` role from selecting the `netlify_api_token` column
- Server-side edge functions running under `service_role` bypass column-level RLS and can still read the token for API calls
- Existing row-level policies remain unchanged, allowing users to manage their own settings
- This approach maintains usability (users can save tokens) while preventing accidental token exposure to the frontend

https://claude.ai/code/session_01XGxq4qMPi1BhjsSh9ynf88