### PR TITLE
feat: add Breadcrumbs feature for tracking scattered conversations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,9 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useAuth } from "./hooks/useAuth";
 import { useProjects } from "./hooks/useProjects";
 import { useSettings } from "./hooks/useSettings";
+import { useBreadcrumbs } from "./hooks/useBreadcrumbs";
 import { LoginScreen } from "./components/LoginScreen";
+import { BreadcrumbForm, BreadcrumbList, BreadcrumbCard } from "./components/Breadcrumbs";
 import { daysSince, fmtDate, fmtDateTime, fmtDuration, timeAgo } from "./lib/helpers";
 
 /* ─── constants ──────────────────────────────────────────── */
@@ -366,7 +368,7 @@ function Editable({ field, label, value, multi, editing, tempValue, onTempChange
 }
 
 /* ─── project detail ─────────────────────────────────────── */
-function Detail({ project, actions, onBack }) {
+function Detail({ project, actions, breadcrumbs, onUpdateBreadcrumb, onDeleteBreadcrumb, onBack }) {
   const [editingField, setEditingField] = useState(null);
   const [tempValue, setTempValue] = useState("");
   const [newTask, setNewTask] = useState("");
@@ -432,6 +434,17 @@ function Detail({ project, actions, onBack }) {
         {project.tasks.length === 0 && <p className="text-sm text-slate-500 text-center py-6">No tasks yet — add one above</p>}
       </section>
 
+      {breadcrumbs?.length > 0 && (
+        <section>
+          <h3 className="text-lg font-semibold text-slate-200 mb-4">Breadcrumbs</h3>
+          <div className="space-y-3">
+            {breadcrumbs.map((b) => (
+              <BreadcrumbCard key={b.id} breadcrumb={b} onUpdate={onUpdateBreadcrumb} onDelete={onDeleteBreadcrumb} />
+            ))}
+          </div>
+        </section>
+      )}
+
       <div className="border-t border-slate-800 pt-6">
         {showDelete ? <div className="flex items-center gap-3 bg-red-950/30 border border-red-900/40 rounded-lg p-4"><p className="text-sm text-red-300 flex-1">Permanently delete "{project.name || "this project"}"?</p><button onClick={() => { actions.deleteProject(project.id); onBack(); }} className="px-3 py-1.5 bg-red-600 hover:bg-red-500 rounded-lg text-sm font-medium text-white transition-colors">Delete</button><button onClick={() => setShowDelete(false)} className="px-3 py-1.5 bg-slate-700 hover:bg-slate-600 rounded-lg text-sm text-slate-300 transition-colors">Cancel</button></div>
           : <button onClick={() => setShowDelete(true)} className="text-sm text-slate-500 hover:text-red-400 transition-colors">Delete project</button>}
@@ -455,6 +468,9 @@ export default function App() {
     syncNetlifyDeploys, syncGithubActivity,
   } = useProjects(user?.id);
   const { saveTokens } = useSettings(user?.id);
+  const {
+    breadcrumbs, createBreadcrumb, updateBreadcrumb, deleteBreadcrumb,
+  } = useBreadcrumbs(user?.id);
 
   const [view, setView] = useState("overview");
   const [selectedId, setSelectedId] = useState(null);
@@ -485,7 +501,7 @@ export default function App() {
         {view !== "detail" && (
           <div className="flex items-center justify-between mb-6">
             <nav className="flex items-center gap-1 flex-1 bg-slate-800/60 rounded-xl p-1 border border-slate-700/50">
-              {["overview", "projects"].map((v) => <button key={v} onClick={() => setView(v)} className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${view === v ? "bg-slate-700 text-white" : "text-slate-400 hover:text-slate-200"}`}>{v === "overview" ? "Overview" : `Projects (${projects.length})`}</button>)}
+              {[["overview", "Overview"], ["projects", `Projects (${projects.length})`], ["breadcrumbs", "Breadcrumbs"]].map(([v, label]) => <button key={v} onClick={() => setView(v)} className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${view === v ? "bg-slate-700 text-white" : "text-slate-400 hover:text-slate-200"}`}>{label}</button>)}
               <button onClick={handleNew} className="px-3 py-2 bg-blue-600 hover:bg-blue-500 rounded-lg text-sm font-medium text-white transition-colors flex items-center gap-1.5" aria-label="Add new project"><IconPlus size={16} /><span className="hidden sm:inline">New</span></button>
             </nav>
             <button onClick={() => setShowSettings(true)} className="ml-3 p-2 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors" aria-label="Settings" title="Settings"><IconSettings size={18} /></button>
@@ -503,7 +519,15 @@ export default function App() {
           </div>
         )}
 
-        {view === "detail" && selected && <Detail project={selected} actions={actions} onBack={() => setView("overview")} />}
+        {view === "breadcrumbs" && (
+          <div className="space-y-6">
+            <h1 className="text-2xl font-bold text-slate-100">Breadcrumbs</h1>
+            <BreadcrumbForm onCreate={createBreadcrumb} projects={projects} />
+            <BreadcrumbList breadcrumbs={breadcrumbs} onUpdate={updateBreadcrumb} onDelete={deleteBreadcrumb} projects={projects} />
+          </div>
+        )}
+
+        {view === "detail" && selected && <Detail project={selected} actions={actions} breadcrumbs={breadcrumbs.filter((b) => b.projectId === selected.id)} onUpdateBreadcrumb={updateBreadcrumb} onDeleteBreadcrumb={deleteBreadcrumb} onBack={() => setView("overview")} />}
       </div>
       {showSettings && <SettingsModal onClose={() => setShowSettings(false)} saveTokens={saveTokens} />}
     </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -501,7 +501,24 @@ export default function App() {
         {view !== "detail" && (
           <div className="flex items-center justify-between mb-6">
             <nav className="flex items-center gap-1 flex-1 bg-slate-800/60 rounded-xl p-1 border border-slate-700/50">
-              {[["overview", "Overview"], ["projects", `Projects (${projects.length})`], ["breadcrumbs", "Breadcrumbs"]].map(([v, label]) => <button key={v} onClick={() => setView(v)} className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${view === v ? "bg-slate-700 text-white" : "text-slate-400 hover:text-slate-200"}`}>{label}</button>)}
+              {[
+                ["overview", "Overview"],
+                ["projects", `Projects (${projects.length})`],
+                ["breadcrumbs", "Breadcrumbs"],
+              ].map(([v, label]) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => setView(v)}
+                  className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                    view === v
+                      ? "bg-slate-700 text-white"
+                      : "text-slate-400 hover:text-slate-200"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
               <button onClick={handleNew} className="px-3 py-2 bg-blue-600 hover:bg-blue-500 rounded-lg text-sm font-medium text-white transition-colors flex items-center gap-1.5" aria-label="Add new project"><IconPlus size={16} /><span className="hidden sm:inline">New</span></button>
             </nav>
             <button onClick={() => setShowSettings(true)} className="ml-3 p-2 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors" aria-label="Settings" title="Settings"><IconSettings size={18} /></button>

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -182,6 +182,7 @@ export function BreadcrumbCard({ breadcrumb, onUpdate, onDelete, projectName }) 
       <div className="flex gap-2">
         {status !== "open" && (
           <button
+            type="button"
             onClick={() => onUpdate(id, { status: "open" })}
             className="text-xs text-slate-400 hover:text-sky-300 transition-colors"
           >
@@ -190,6 +191,7 @@ export function BreadcrumbCard({ breadcrumb, onUpdate, onDelete, projectName }) 
         )}
         {status !== "waiting" && (
           <button
+            type="button"
             onClick={() => onUpdate(id, { status: "waiting" })}
             className="text-xs text-slate-400 hover:text-amber-300 transition-colors"
           >
@@ -198,6 +200,7 @@ export function BreadcrumbCard({ breadcrumb, onUpdate, onDelete, projectName }) 
         )}
         {status !== "resolved" && (
           <button
+            type="button"
             onClick={() => onUpdate(id, { status: "resolved" })}
             className="text-xs text-slate-400 hover:text-emerald-300 transition-colors"
           >
@@ -205,6 +208,7 @@ export function BreadcrumbCard({ breadcrumb, onUpdate, onDelete, projectName }) 
           </button>
         )}
         <button
+          type="button"
           onClick={() => onDelete(id)}
           className="text-xs text-slate-400 hover:text-red-400 transition-colors ml-auto"
         >
@@ -245,6 +249,7 @@ export function BreadcrumbList({ breadcrumbs, onUpdate, onDelete, projects }) {
         <div className="flex gap-1 bg-slate-800/50 rounded-lg p-1">
           {STATUS_TABS.map((tab) => (
             <button
+              type="button"
               key={tab}
               onClick={() => setActiveTab(tab)}
               className={`px-3 py-1.5 text-sm rounded-md capitalize transition-colors ${

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -9,8 +9,6 @@ export function BreadcrumbForm({ onCreate, projects }) {
   const [source, setSource] = useState("");
   const [sourceUrl, setSourceUrl] = useState("");
   const [projectId, setProjectId] = useState("");
-  const [showDetails, setShowDetails] = useState(false);
-
   const handleSubmit = (e) => {
     e.preventDefault();
     if (!note.trim()) return;
@@ -50,16 +48,11 @@ export function BreadcrumbForm({ onCreate, projects }) {
         </button>
       </div>
 
-      <button
-        type="button"
-        onClick={() => setShowDetails(!showDetails)}
-        className="text-sm text-slate-400 hover:text-slate-300 transition-colors"
-      >
-        {showDetails ? "Less details" : "More details"}
-      </button>
-
-      {showDetails && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+      <details className="group">
+        <summary className="text-sm text-slate-400 hover:text-slate-300 transition-colors cursor-pointer list-none">
+          More details
+        </summary>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
           <div>
             <label htmlFor="breadcrumb-who" className="sr-only">Who was involved</label>
             <input
@@ -112,7 +105,7 @@ export function BreadcrumbForm({ onCreate, projects }) {
             </div>
           )}
         </div>
-      )}
+      </details>
     </form>
   );
 }

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -1,0 +1,270 @@
+import { useState } from "react";
+import { linkify } from "../lib/linkify";
+import { timeAgo } from "../lib/helpers";
+
+// ─── Quick-capture form ────────────────────────────────────
+export function BreadcrumbForm({ onCreate, projects }) {
+  const [note, setNote] = useState("");
+  const [who, setWho] = useState("");
+  const [source, setSource] = useState("");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [projectId, setProjectId] = useState("");
+  const [showDetails, setShowDetails] = useState(false);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!note.trim()) return;
+
+    onCreate({
+      note: note.trim(),
+      who: who.trim() || undefined,
+      source: source.trim() || undefined,
+      sourceUrl: sourceUrl.trim() || undefined,
+      projectId: projectId || undefined,
+    });
+
+    setNote("");
+    setWho("");
+    setSource("");
+    setSourceUrl("");
+    setProjectId("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="What did you hear? Quick-capture a breadcrumb…"
+          className="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-4 py-2.5 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+        />
+        <button
+          type="submit"
+          className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 text-white font-medium rounded-lg transition-colors"
+        >
+          Save
+        </button>
+      </div>
+
+      <button
+        type="button"
+        onClick={() => setShowDetails(!showDetails)}
+        className="text-sm text-slate-400 hover:text-slate-300 transition-colors"
+      >
+        {showDetails ? "Less details" : "More details"}
+      </button>
+
+      {showDetails && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <input
+            type="text"
+            value={who}
+            onChange={(e) => setWho(e.target.value)}
+            placeholder="Who was involved? e.g. @alice, @bob"
+            className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+          />
+          <input
+            type="text"
+            value={source}
+            onChange={(e) => setSource(e.target.value)}
+            placeholder="Where? e.g. #backend, DM, Jira-123"
+            className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+          />
+          <input
+            type="url"
+            value={sourceUrl}
+            onChange={(e) => setSourceUrl(e.target.value)}
+            placeholder="Link (optional)"
+            className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+          />
+          {projects?.length > 0 && (
+            <select
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+            >
+              <option value="">No project</option>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name || "Untitled"}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+      )}
+    </form>
+  );
+}
+
+// ─── Single breadcrumb card ────────────────────────────────
+export function BreadcrumbCard({ breadcrumb, onUpdate, onDelete, projectName }) {
+  const { id, note, who, source, sourceUrl, status, createdAt } = breadcrumb;
+
+  const statusStyles = {
+    open: "bg-sky-500/20 text-sky-300",
+    waiting: "bg-amber-500/20 text-amber-300",
+    resolved: "bg-emerald-500/20 text-emerald-300",
+  };
+
+  const segments = linkify(note);
+
+  return (
+    <div className="bg-slate-800/50 border border-slate-700/50 rounded-xl p-4 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-slate-200 flex-1">
+          {segments.map((seg, i) =>
+            seg.type === "link" ? (
+              <a
+                key={i}
+                href={seg.value}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sky-400 hover:text-sky-300 underline underline-offset-2"
+              >
+                {seg.value}
+              </a>
+            ) : (
+              <span key={i}>{seg.value}</span>
+            )
+          )}
+        </p>
+        <span
+          className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full ${statusStyles[status]}`}
+        >
+          {status}
+        </span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+        {who && <span>👤 {who}</span>}
+        {source && (
+          <span>
+            📍{" "}
+            {sourceUrl ? (
+              <a
+                href={sourceUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sky-400 hover:text-sky-300 underline underline-offset-2"
+              >
+                {source}
+              </a>
+            ) : (
+              source
+            )}
+          </span>
+        )}
+        {projectName && <span>📁 {projectName}</span>}
+        <span>{timeAgo(createdAt)}</span>
+      </div>
+
+      <div className="flex gap-2">
+        {status !== "open" && (
+          <button
+            onClick={() => onUpdate(id, { status: "open" })}
+            className="text-xs text-slate-400 hover:text-sky-300 transition-colors"
+          >
+            Open
+          </button>
+        )}
+        {status !== "waiting" && (
+          <button
+            onClick={() => onUpdate(id, { status: "waiting" })}
+            className="text-xs text-slate-400 hover:text-amber-300 transition-colors"
+          >
+            Waiting
+          </button>
+        )}
+        {status !== "resolved" && (
+          <button
+            onClick={() => onUpdate(id, { status: "resolved" })}
+            className="text-xs text-slate-400 hover:text-emerald-300 transition-colors"
+          >
+            Resolved
+          </button>
+        )}
+        <button
+          onClick={() => onDelete(id)}
+          className="text-xs text-slate-400 hover:text-red-400 transition-colors ml-auto"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Filterable breadcrumb list ────────────────────────────
+const STATUS_TABS = ["all", "open", "waiting", "resolved"];
+
+export function BreadcrumbList({ breadcrumbs, onUpdate, onDelete, projects }) {
+  const [activeTab, setActiveTab] = useState("all");
+  const [search, setSearch] = useState("");
+
+  const projectMap = Object.fromEntries(
+    (projects || []).map((p) => [p.id, p.name || "Untitled"])
+  );
+
+  const filtered = breadcrumbs.filter((b) => {
+    if (activeTab !== "all" && b.status !== activeTab) return false;
+    if (search) {
+      const q = search.toLowerCase();
+      const haystack = [b.note, b.who, b.source]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      if (!haystack.includes(q)) return false;
+    }
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="flex gap-1 bg-slate-800/50 rounded-lg p-1">
+          {STATUS_TABS.map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-3 py-1.5 text-sm rounded-md capitalize transition-colors ${
+                activeTab === tab
+                  ? "bg-slate-700 text-slate-100"
+                  : "text-slate-400 hover:text-slate-200"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search breadcrumbs…"
+          className="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+        />
+      </div>
+
+      <div className="space-y-3">
+        {filtered.length === 0 ? (
+          <p className="text-center text-slate-500 py-8">
+            No breadcrumbs found.
+          </p>
+        ) : (
+          filtered.map((b) => (
+            <BreadcrumbCard
+              key={b.id}
+              breadcrumb={b}
+              onUpdate={onUpdate}
+              onDelete={onDelete}
+              projectName={b.projectId ? projectMap[b.projectId] : null}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -33,7 +33,9 @@ export function BreadcrumbForm({ onCreate, projects }) {
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
       <div className="flex gap-2">
+        <label htmlFor="breadcrumb-note" className="sr-only">Note</label>
         <input
+          id="breadcrumb-note"
           type="text"
           value={note}
           onChange={(e) => setNote(e.target.value)}
@@ -58,40 +60,56 @@ export function BreadcrumbForm({ onCreate, projects }) {
 
       {showDetails && (
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <input
-            type="text"
-            value={who}
-            onChange={(e) => setWho(e.target.value)}
-            placeholder="Who was involved? e.g. @alice, @bob"
-            className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
-          />
-          <input
-            type="text"
-            value={source}
-            onChange={(e) => setSource(e.target.value)}
-            placeholder="Where? e.g. #backend, DM, Jira-123"
-            className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
-          />
-          <input
-            type="url"
-            value={sourceUrl}
-            onChange={(e) => setSourceUrl(e.target.value)}
-            placeholder="Link (optional)"
-            className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
-          />
+          <div>
+            <label htmlFor="breadcrumb-who" className="sr-only">Who was involved</label>
+            <input
+              id="breadcrumb-who"
+              type="text"
+              value={who}
+              onChange={(e) => setWho(e.target.value)}
+              placeholder="Who was involved? e.g. @alice, @bob"
+              className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+            />
+          </div>
+          <div>
+            <label htmlFor="breadcrumb-source" className="sr-only">Source</label>
+            <input
+              id="breadcrumb-source"
+              type="text"
+              value={source}
+              onChange={(e) => setSource(e.target.value)}
+              placeholder="Where? e.g. #backend, DM, Jira-123"
+              className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+            />
+          </div>
+          <div>
+            <label htmlFor="breadcrumb-source-url" className="sr-only">Source link</label>
+            <input
+              id="breadcrumb-source-url"
+              type="url"
+              value={sourceUrl}
+              onChange={(e) => setSourceUrl(e.target.value)}
+              placeholder="Link (optional)"
+              className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+            />
+          </div>
           {projects?.length > 0 && (
-            <select
-              value={projectId}
-              onChange={(e) => setProjectId(e.target.value)}
-              className="bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
-            >
+            <div>
+              <label htmlFor="breadcrumb-project" className="sr-only">Linked project</label>
+              <select
+                id="breadcrumb-project"
+                value={projectId}
+                onChange={(e) => setProjectId(e.target.value)}
+                className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+              >
               <option value="">No project</option>
               {projects.map((p) => (
                 <option key={p.id} value={p.id}>
                   {p.name || "Untitled"}
                 </option>
               ))}
-            </select>
+              </select>
+            </div>
           )}
         </div>
       )}
@@ -239,13 +257,17 @@ export function BreadcrumbList({ breadcrumbs, onUpdate, onDelete, projects }) {
             </button>
           ))}
         </div>
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search breadcrumbs…"
-          className="flex-1 bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
-        />
+        <div className="flex-1">
+          <label htmlFor="breadcrumb-search" className="sr-only">Search breadcrumbs</label>
+          <input
+            id="breadcrumb-search"
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search breadcrumbs…"
+            className="w-full bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
+          />
+        </div>
       </div>
 
       <div className="space-y-3">

--- a/src/components/Breadcrumbs.test.jsx
+++ b/src/components/Breadcrumbs.test.jsx
@@ -54,18 +54,16 @@ describe("BreadcrumbForm", () => {
     expect(input).toHaveValue("");
   });
 
-  it("reveals detail fields when 'More details' is toggled", async () => {
+  it("reveals detail fields when details/summary is toggled", async () => {
     const user = userEvent.setup();
-    render(<BreadcrumbForm onCreate={vi.fn()} />);
+    const { container } = render(<BreadcrumbForm onCreate={vi.fn()} />);
 
-    expect(
-      screen.queryByRole("textbox", { name: /who was involved/i })
-    ).not.toBeInTheDocument();
+    const details = container.querySelector("details");
+    expect(details).not.toHaveAttribute("open");
 
-    await user.click(
-      screen.getByRole("button", { name: /more details/i })
-    );
+    await user.click(screen.getByText(/more details/i));
 
+    expect(details).toHaveAttribute("open");
     expect(
       screen.getByRole("textbox", { name: /who was involved/i })
     ).toBeInTheDocument();
@@ -81,9 +79,7 @@ describe("BreadcrumbForm", () => {
       screen.getByRole("textbox", { name: /note/i }),
       "API design discussion"
     );
-    await user.click(
-      screen.getByRole("button", { name: /more details/i })
-    );
+    await user.click(screen.getByText(/more details/i));
     await user.type(
       screen.getByRole("textbox", { name: /who was involved/i }),
       "@alice"

--- a/src/components/Breadcrumbs.test.jsx
+++ b/src/components/Breadcrumbs.test.jsx
@@ -12,7 +12,7 @@ describe("BreadcrumbForm", () => {
     render(<BreadcrumbForm onCreate={vi.fn()} />);
 
     expect(
-      screen.getByPlaceholderText(/what did you hear/i)
+      screen.getByRole("textbox", { name: /note/i })
     ).toBeInTheDocument();
   });
 
@@ -22,7 +22,7 @@ describe("BreadcrumbForm", () => {
     render(<BreadcrumbForm onCreate={onCreate} />);
 
     await user.type(
-      screen.getByPlaceholderText(/what did you hear/i),
+      screen.getByRole("textbox", { name: /note/i }),
       "Check auth with Alice"
     );
     await user.click(screen.getByRole("button", { name: /save/i }));
@@ -47,7 +47,7 @@ describe("BreadcrumbForm", () => {
     const user = userEvent.setup();
     render(<BreadcrumbForm onCreate={onCreate} />);
 
-    const input = screen.getByPlaceholderText(/what did you hear/i);
+    const input = screen.getByRole("textbox", { name: /note/i });
     await user.type(input, "Some note");
     await user.click(screen.getByRole("button", { name: /save/i }));
 
@@ -59,7 +59,7 @@ describe("BreadcrumbForm", () => {
     render(<BreadcrumbForm onCreate={vi.fn()} />);
 
     expect(
-      screen.queryByPlaceholderText(/who was involved/i)
+      screen.queryByRole("textbox", { name: /who was involved/i })
     ).not.toBeInTheDocument();
 
     await user.click(
@@ -67,9 +67,9 @@ describe("BreadcrumbForm", () => {
     );
 
     expect(
-      screen.getByPlaceholderText(/who was involved/i)
+      screen.getByRole("textbox", { name: /who was involved/i })
     ).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(/where/i)).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: /^source$/i })).toBeInTheDocument();
   });
 
   it("includes detail fields in submission", async () => {
@@ -78,17 +78,17 @@ describe("BreadcrumbForm", () => {
     render(<BreadcrumbForm onCreate={onCreate} />);
 
     await user.type(
-      screen.getByPlaceholderText(/what did you hear/i),
+      screen.getByRole("textbox", { name: /note/i }),
       "API design discussion"
     );
     await user.click(
       screen.getByRole("button", { name: /more details/i })
     );
     await user.type(
-      screen.getByPlaceholderText(/who was involved/i),
+      screen.getByRole("textbox", { name: /who was involved/i }),
       "@alice"
     );
-    await user.type(screen.getByPlaceholderText(/where/i), "#backend");
+    await user.type(screen.getByRole("textbox", { name: /^source$/i }), "#backend");
     await user.click(screen.getByRole("button", { name: /save/i }));
 
     expect(onCreate).toHaveBeenCalledWith(
@@ -280,7 +280,7 @@ describe("BreadcrumbList", () => {
     );
 
     await user.type(
-      screen.getByPlaceholderText(/search/i),
+      screen.getByRole("textbox", { name: /search/i }),
       "deploy"
     );
 
@@ -299,7 +299,7 @@ describe("BreadcrumbList", () => {
     );
 
     await user.type(
-      screen.getByPlaceholderText(/search/i),
+      screen.getByRole("textbox", { name: /search/i }),
       "zzzznonexistent"
     );
 

--- a/src/components/Breadcrumbs.test.jsx
+++ b/src/components/Breadcrumbs.test.jsx
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  BreadcrumbForm,
+  BreadcrumbCard,
+  BreadcrumbList,
+} from "./Breadcrumbs";
+
+describe("BreadcrumbForm", () => {
+  it("renders the note input", () => {
+    render(<BreadcrumbForm onCreate={vi.fn()} />);
+
+    expect(
+      screen.getByPlaceholderText(/what did you hear/i)
+    ).toBeInTheDocument();
+  });
+
+  it("calls onCreate with note when submitted", async () => {
+    const onCreate = vi.fn();
+    const user = userEvent.setup();
+    render(<BreadcrumbForm onCreate={onCreate} />);
+
+    await user.type(
+      screen.getByPlaceholderText(/what did you hear/i),
+      "Check auth with Alice"
+    );
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ note: "Check auth with Alice" })
+    );
+  });
+
+  it("does not submit when note is empty", async () => {
+    const onCreate = vi.fn();
+    const user = userEvent.setup();
+    render(<BreadcrumbForm onCreate={onCreate} />);
+
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onCreate).not.toHaveBeenCalled();
+  });
+
+  it("clears the form after successful submission", async () => {
+    const onCreate = vi.fn();
+    const user = userEvent.setup();
+    render(<BreadcrumbForm onCreate={onCreate} />);
+
+    const input = screen.getByPlaceholderText(/what did you hear/i);
+    await user.type(input, "Some note");
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(input).toHaveValue("");
+  });
+
+  it("reveals detail fields when 'More details' is toggled", async () => {
+    const user = userEvent.setup();
+    render(<BreadcrumbForm onCreate={vi.fn()} />);
+
+    expect(
+      screen.queryByPlaceholderText(/who was involved/i)
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: /more details/i })
+    );
+
+    expect(
+      screen.getByPlaceholderText(/who was involved/i)
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/where/i)).toBeInTheDocument();
+  });
+
+  it("includes detail fields in submission", async () => {
+    const onCreate = vi.fn();
+    const user = userEvent.setup();
+    render(<BreadcrumbForm onCreate={onCreate} />);
+
+    await user.type(
+      screen.getByPlaceholderText(/what did you hear/i),
+      "API design discussion"
+    );
+    await user.click(
+      screen.getByRole("button", { name: /more details/i })
+    );
+    await user.type(
+      screen.getByPlaceholderText(/who was involved/i),
+      "@alice"
+    );
+    await user.type(screen.getByPlaceholderText(/where/i), "#backend");
+    await user.click(screen.getByRole("button", { name: /save/i }));
+
+    expect(onCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        note: "API design discussion",
+        who: "@alice",
+        source: "#backend",
+      })
+    );
+  });
+});
+
+describe("BreadcrumbCard", () => {
+  const baseCrumb = {
+    id: "b1",
+    note: "Follow up on deploy pipeline",
+    who: "@bob",
+    source: "#devops",
+    sourceUrl: null,
+    projectId: null,
+    status: "open",
+    createdAt: "2026-04-01T10:00:00Z",
+    updatedAt: "2026-04-01T10:00:00Z",
+  };
+
+  it("renders the note text", () => {
+    render(
+      <BreadcrumbCard
+        breadcrumb={baseCrumb}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/follow up on deploy pipeline/i)).toBeInTheDocument();
+  });
+
+  it("renders who and source when present", () => {
+    render(
+      <BreadcrumbCard
+        breadcrumb={baseCrumb}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/@bob/)).toBeInTheDocument();
+    expect(screen.getByText(/#devops/)).toBeInTheDocument();
+  });
+
+  it("renders URLs in notes as clickable links", () => {
+    const crumb = {
+      ...baseCrumb,
+      note: "See https://example.com/issue/123 for details",
+    };
+    render(
+      <BreadcrumbCard
+        breadcrumb={crumb}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    const link = screen.getByRole("link", {
+      name: "https://example.com/issue/123",
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://example.com/issue/123"
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("calls onUpdate with new status when status is changed", async () => {
+    const onUpdate = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BreadcrumbCard
+        breadcrumb={baseCrumb}
+        onUpdate={onUpdate}
+        onDelete={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /resolved/i }));
+
+    expect(onUpdate).toHaveBeenCalledWith("b1", { status: "resolved" });
+  });
+
+  it("calls onDelete when delete button is clicked", async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BreadcrumbCard
+        breadcrumb={baseCrumb}
+        onUpdate={vi.fn()}
+        onDelete={onDelete}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /delete/i }));
+
+    expect(onDelete).toHaveBeenCalledWith("b1");
+  });
+});
+
+describe("BreadcrumbList", () => {
+  const crumbs = [
+    {
+      id: "b1",
+      note: "Auth discussion",
+      who: "@alice",
+      source: "#backend",
+      sourceUrl: null,
+      projectId: null,
+      status: "open",
+      createdAt: "2026-04-01T10:00:00Z",
+      updatedAt: "2026-04-01T10:00:00Z",
+    },
+    {
+      id: "b2",
+      note: "Deploy pipeline review",
+      who: "@bob",
+      source: "DM",
+      sourceUrl: null,
+      projectId: null,
+      status: "resolved",
+      createdAt: "2026-04-02T10:00:00Z",
+      updatedAt: "2026-04-02T10:00:00Z",
+    },
+    {
+      id: "b3",
+      note: "Waiting on API feedback",
+      who: null,
+      source: null,
+      sourceUrl: null,
+      projectId: null,
+      status: "waiting",
+      createdAt: "2026-04-03T10:00:00Z",
+      updatedAt: "2026-04-03T10:00:00Z",
+    },
+  ];
+
+  it("renders all breadcrumbs by default", () => {
+    render(
+      <BreadcrumbList
+        breadcrumbs={crumbs}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/auth discussion/i)).toBeInTheDocument();
+    expect(screen.getByText(/deploy pipeline review/i)).toBeInTheDocument();
+    expect(screen.getByText(/waiting on api feedback/i)).toBeInTheDocument();
+  });
+
+  it("filters by status when a tab is selected", async () => {
+    const user = userEvent.setup();
+    render(
+      <BreadcrumbList
+        breadcrumbs={crumbs}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    // Click the "open" filter tab (first one in the tab bar)
+    const tabs = screen.getAllByRole("button", { name: /^open$/i });
+    await user.click(tabs[0]);
+
+    expect(screen.getByText(/auth discussion/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/deploy pipeline review/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/waiting on api feedback/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters by search text", async () => {
+    const user = userEvent.setup();
+    render(
+      <BreadcrumbList
+        breadcrumbs={crumbs}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    await user.type(
+      screen.getByPlaceholderText(/search/i),
+      "deploy"
+    );
+
+    expect(screen.getByText(/deploy pipeline review/i)).toBeInTheDocument();
+    expect(screen.queryByText(/auth discussion/i)).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no breadcrumbs match", async () => {
+    const user = userEvent.setup();
+    render(
+      <BreadcrumbList
+        breadcrumbs={crumbs}
+        onUpdate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+
+    await user.type(
+      screen.getByPlaceholderText(/search/i),
+      "zzzznonexistent"
+    );
+
+    expect(screen.getByText(/no breadcrumbs/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useBreadcrumbs.js
+++ b/src/hooks/useBreadcrumbs.js
@@ -1,0 +1,125 @@
+import { useState, useEffect, useCallback } from "react";
+import { supabase } from "../lib/supabase";
+
+export function useBreadcrumbs(userId) {
+  const [breadcrumbs, setBreadcrumbs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchBreadcrumbs = useCallback(async () => {
+    if (!userId) return;
+
+    const { data, error: fetchError } = await supabase
+      .from("breadcrumbs")
+      .select("*")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false });
+
+    if (fetchError) {
+      setError(fetchError.message);
+      console.error("Fetch breadcrumbs error:", fetchError);
+    } else {
+      setBreadcrumbs((data || []).map(normalize));
+    }
+
+    setLoading(false);
+  }, [userId]);
+
+  useEffect(() => {
+    fetchBreadcrumbs();
+  }, [fetchBreadcrumbs]);
+
+  const createBreadcrumb = useCallback(
+    async ({ note, who, source, sourceUrl, projectId }) => {
+      const { data, error } = await supabase
+        .from("breadcrumbs")
+        .insert({
+          user_id: userId,
+          note,
+          who: who || null,
+          source: source || null,
+          source_url: sourceUrl || null,
+          project_id: projectId || null,
+        })
+        .select()
+        .single();
+
+      if (error) {
+        console.error("Create breadcrumb error:", error);
+        return null;
+      }
+
+      const created = normalize(data);
+      setBreadcrumbs((prev) => [created, ...prev]);
+      return created;
+    },
+    [userId]
+  );
+
+  const updateBreadcrumb = useCallback(async (id, updates) => {
+    const payload = {};
+    if ("note" in updates) payload.note = updates.note;
+    if ("who" in updates) payload.who = updates.who;
+    if ("source" in updates) payload.source = updates.source;
+    if ("sourceUrl" in updates) payload.source_url = updates.sourceUrl;
+    if ("projectId" in updates) payload.project_id = updates.projectId;
+    if ("status" in updates) payload.status = updates.status;
+    payload.updated_at = new Date().toISOString();
+
+    const { error } = await supabase
+      .from("breadcrumbs")
+      .update(payload)
+      .eq("id", id);
+
+    if (error) {
+      console.error("Update breadcrumb error:", error);
+      return;
+    }
+
+    setBreadcrumbs((prev) =>
+      prev.map((b) =>
+        b.id === id
+          ? { ...b, ...updates, updatedAt: payload.updated_at }
+          : b
+      )
+    );
+  }, []);
+
+  const deleteBreadcrumb = useCallback(async (id) => {
+    const { error } = await supabase
+      .from("breadcrumbs")
+      .delete()
+      .eq("id", id);
+
+    if (error) {
+      console.error("Delete breadcrumb error:", error);
+      return;
+    }
+
+    setBreadcrumbs((prev) => prev.filter((b) => b.id !== id));
+  }, []);
+
+  return {
+    breadcrumbs,
+    loading,
+    error,
+    createBreadcrumb,
+    updateBreadcrumb,
+    deleteBreadcrumb,
+    refetch: fetchBreadcrumbs,
+  };
+}
+
+function normalize(row) {
+  return {
+    id: row.id,
+    note: row.note,
+    who: row.who,
+    source: row.source,
+    sourceUrl: row.source_url,
+    projectId: row.project_id,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}

--- a/src/hooks/useBreadcrumbs.js
+++ b/src/hooks/useBreadcrumbs.js
@@ -62,14 +62,21 @@ export function useBreadcrumbs(userId) {
   );
 
   const updateBreadcrumb = useCallback(async (id, updates) => {
-    const payload = {};
-    if ("note" in updates) payload.note = updates.note;
-    if ("who" in updates) payload.who = updates.who;
-    if ("source" in updates) payload.source = updates.source;
-    if ("sourceUrl" in updates) payload.source_url = updates.sourceUrl;
-    if ("projectId" in updates) payload.project_id = updates.projectId;
-    if ("status" in updates) payload.status = updates.status;
-    payload.updated_at = new Date().toISOString();
+    const FIELD_MAP = {
+      note: "note",
+      who: "who",
+      source: "source",
+      sourceUrl: "source_url",
+      projectId: "project_id",
+      status: "status",
+    };
+
+    const payload = { updated_at: new Date().toISOString() };
+    for (const [key, column] of Object.entries(FIELD_MAP)) {
+      if (key in updates) {
+        payload[column] = updates[key];
+      }
+    }
 
     const { error } = await supabase
       .from("breadcrumbs")

--- a/src/hooks/useBreadcrumbs.js
+++ b/src/hooks/useBreadcrumbs.js
@@ -6,14 +6,17 @@ export function useBreadcrumbs(userId) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchBreadcrumbs = useCallback(async () => {
+  const fetchBreadcrumbs = useCallback(async (signal) => {
     if (!userId) return;
 
     const { data, error: fetchError } = await supabase
       .from("breadcrumbs")
       .select("*")
       .eq("user_id", userId)
-      .order("created_at", { ascending: false });
+      .order("created_at", { ascending: false })
+      .abortSignal(signal);
+
+    if (signal?.aborted) return;
 
     if (fetchError) {
       setError(fetchError.message);
@@ -26,7 +29,9 @@ export function useBreadcrumbs(userId) {
   }, [userId]);
 
   useEffect(() => {
-    fetchBreadcrumbs();
+    const controller = new AbortController();
+    fetchBreadcrumbs(controller.signal);
+    return () => controller.abort();
   }, [fetchBreadcrumbs]);
 
   const createBreadcrumb = useCallback(

--- a/src/hooks/useBreadcrumbs.test.js
+++ b/src/hooks/useBreadcrumbs.test.js
@@ -18,6 +18,7 @@ function mockChain(resolvedValue = { data: [], error: null }) {
     ilike: vi.fn().mockReturnThis(),
     or: vi.fn().mockReturnThis(),
     order: vi.fn().mockReturnThis(),
+    abortSignal: vi.fn().mockReturnThis(),
     single: vi.fn().mockResolvedValue(resolvedValue),
     then: (resolve) => resolve(resolvedValue),
   };

--- a/src/hooks/useBreadcrumbs.test.js
+++ b/src/hooks/useBreadcrumbs.test.js
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useBreadcrumbs } from "./useBreadcrumbs";
+import { supabase } from "../lib/supabase";
+
+vi.mock("../lib/supabase");
+
+const USER_ID = "user-123";
+
+// Helper to make a chainable mock that resolves to the given value
+function mockChain(resolvedValue = { data: [], error: null }) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    ilike: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(resolvedValue),
+    then: (resolve) => resolve(resolvedValue),
+  };
+  return chain;
+}
+
+describe("useBreadcrumbs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches breadcrumbs on mount", async () => {
+    const rows = [
+      {
+        id: "b1",
+        user_id: USER_ID,
+        note: "Check auth approach with Alice",
+        who: "@alice",
+        source: "#backend",
+        source_url: null,
+        project_id: null,
+        status: "open",
+        created_at: "2026-04-01T10:00:00Z",
+        updated_at: "2026-04-01T10:00:00Z",
+      },
+    ];
+
+    supabase.from.mockReturnValue(mockChain({ data: rows, error: null }));
+
+    const { result } = renderHook(() => useBreadcrumbs(USER_ID));
+
+    // Wait for useEffect to resolve
+    await act(() => Promise.resolve());
+
+    expect(supabase.from).toHaveBeenCalledWith("breadcrumbs");
+    expect(result.current.breadcrumbs).toHaveLength(1);
+    expect(result.current.breadcrumbs[0]).toEqual({
+      id: "b1",
+      note: "Check auth approach with Alice",
+      who: "@alice",
+      source: "#backend",
+      sourceUrl: null,
+      projectId: null,
+      status: "open",
+      createdAt: "2026-04-01T10:00:00Z",
+      updatedAt: "2026-04-01T10:00:00Z",
+    });
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("returns empty array when userId is not provided", async () => {
+    const { result } = renderHook(() => useBreadcrumbs(null));
+
+    await act(() => Promise.resolve());
+
+    expect(supabase.from).not.toHaveBeenCalled();
+    expect(result.current.breadcrumbs).toEqual([]);
+  });
+
+  it("creates a breadcrumb and updates state optimistically", async () => {
+    const newRow = {
+      id: "b2",
+      user_id: USER_ID,
+      note: "Discuss deploy pipeline",
+      who: null,
+      source: null,
+      source_url: null,
+      project_id: null,
+      status: "open",
+      created_at: "2026-04-08T12:00:00Z",
+      updated_at: "2026-04-08T12:00:00Z",
+    };
+
+    // First call: fetch (empty), second call: insert
+    supabase.from
+      .mockReturnValueOnce(mockChain({ data: [], error: null }))
+      .mockReturnValueOnce(
+        mockChain({ data: newRow, error: null })
+      );
+
+    const { result } = renderHook(() => useBreadcrumbs(USER_ID));
+    await act(() => Promise.resolve());
+
+    await act(async () => {
+      await result.current.createBreadcrumb({
+        note: "Discuss deploy pipeline",
+      });
+    });
+
+    expect(result.current.breadcrumbs).toHaveLength(1);
+    expect(result.current.breadcrumbs[0].note).toBe(
+      "Discuss deploy pipeline"
+    );
+  });
+
+  it("updates a breadcrumb status", async () => {
+    const rows = [
+      {
+        id: "b1",
+        user_id: USER_ID,
+        note: "Follow up on API design",
+        who: "@bob",
+        source: "DM",
+        source_url: null,
+        project_id: null,
+        status: "open",
+        created_at: "2026-04-01T10:00:00Z",
+        updated_at: "2026-04-01T10:00:00Z",
+      },
+    ];
+
+    supabase.from
+      .mockReturnValueOnce(mockChain({ data: rows, error: null }))
+      .mockReturnValueOnce(mockChain({ data: null, error: null }));
+
+    const { result } = renderHook(() => useBreadcrumbs(USER_ID));
+    await act(() => Promise.resolve());
+
+    await act(async () => {
+      await result.current.updateBreadcrumb("b1", { status: "resolved" });
+    });
+
+    expect(result.current.breadcrumbs[0].status).toBe("resolved");
+  });
+
+  it("deletes a breadcrumb", async () => {
+    const rows = [
+      {
+        id: "b1",
+        user_id: USER_ID,
+        note: "Old note",
+        who: null,
+        source: null,
+        source_url: null,
+        project_id: null,
+        status: "open",
+        created_at: "2026-04-01T10:00:00Z",
+        updated_at: "2026-04-01T10:00:00Z",
+      },
+    ];
+
+    supabase.from
+      .mockReturnValueOnce(mockChain({ data: rows, error: null }))
+      .mockReturnValueOnce(mockChain({ data: null, error: null }));
+
+    const { result } = renderHook(() => useBreadcrumbs(USER_ID));
+    await act(() => Promise.resolve());
+
+    await act(async () => {
+      await result.current.deleteBreadcrumb("b1");
+    });
+
+    expect(result.current.breadcrumbs).toHaveLength(0);
+  });
+
+  it("sets error when fetch fails", async () => {
+    supabase.from.mockReturnValue(
+      mockChain({ data: null, error: { message: "Network error" } })
+    );
+
+    const { result } = renderHook(() => useBreadcrumbs(USER_ID));
+    await act(() => Promise.resolve());
+
+    expect(result.current.error).toBe("Network error");
+    expect(result.current.breadcrumbs).toEqual([]);
+  });
+});

--- a/src/hooks/useProjects.js
+++ b/src/hooks/useProjects.js
@@ -11,7 +11,7 @@ export function useProjects(userId) {
   const [error, setError] = useState(null);
 
   // ─── Fetch all projects with relations ───────────────────
-  const fetchProjects = useCallback(async () => {
+  const fetchProjects = useCallback(async (signal) => {
     if (!userId) return;
 
     const { data, error: fetchError } = await supabase
@@ -30,7 +30,10 @@ export function useProjects(userId) {
       `)
       .eq("user_id", userId)
       .order("sort_order", { ascending: true })
-      .order("created_at", { ascending: false });
+      .order("created_at", { ascending: false })
+      .abortSignal(signal);
+
+    if (signal?.aborted) return;
 
     if (fetchError) {
       setError(fetchError.message);
@@ -45,7 +48,9 @@ export function useProjects(userId) {
   }, [userId]);
 
   useEffect(() => {
-    fetchProjects();
+    const controller = new AbortController();
+    fetchProjects(controller.signal);
+    return () => controller.abort();
   }, [fetchProjects]);
 
   // ─── Create project ──────────────────────────────────────

--- a/src/lib/__mocks__/supabase.js
+++ b/src/lib/__mocks__/supabase.js
@@ -17,6 +17,7 @@ const queryBuilder = {
   delete: vi.fn().mockReturnThis(),
   eq: vi.fn().mockReturnThis(),
   order: vi.fn().mockReturnThis(),
+  abortSignal: vi.fn().mockReturnThis(),
   single: vi.fn().mockResolvedValue({ data: null, error: null }),
   maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
   // Default: resolves to empty data

--- a/src/lib/linkify.js
+++ b/src/lib/linkify.js
@@ -1,0 +1,27 @@
+const URL_RE = /https?:\/\/[^\s]+/g;
+
+/**
+ * Splits a string into text and link segments.
+ * Returns an array of { type: "text" | "link", value: string }.
+ */
+export function linkify(text) {
+  if (!text) return [];
+
+  const segments = [];
+  let lastIndex = 0;
+  let match;
+
+  while ((match = URL_RE.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: "text", value: text.slice(lastIndex, match.index) });
+    }
+    segments.push({ type: "link", value: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: "text", value: text.slice(lastIndex) });
+  }
+
+  return segments;
+}

--- a/src/lib/linkify.test.js
+++ b/src/lib/linkify.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { linkify } from "./linkify";
+
+describe("linkify", () => {
+  it("returns plain text as a single text segment", () => {
+    const result = linkify("no links here");
+    expect(result).toEqual([{ type: "text", value: "no links here" }]);
+  });
+
+  it("converts an https URL into a link segment", () => {
+    const result = linkify("check https://example.com for details");
+    expect(result).toEqual([
+      { type: "text", value: "check " },
+      { type: "link", value: "https://example.com" },
+      { type: "text", value: " for details" },
+    ]);
+  });
+
+  it("converts an http URL into a link segment", () => {
+    const result = linkify("see http://example.com/path");
+    expect(result).toEqual([
+      { type: "text", value: "see " },
+      { type: "link", value: "http://example.com/path" },
+    ]);
+  });
+
+  it("handles multiple URLs in one string", () => {
+    const result = linkify("a https://one.com b https://two.com c");
+    expect(result).toEqual([
+      { type: "text", value: "a " },
+      { type: "link", value: "https://one.com" },
+      { type: "text", value: " b " },
+      { type: "link", value: "https://two.com" },
+      { type: "text", value: " c" },
+    ]);
+  });
+
+  it("handles a URL at the start of the string", () => {
+    const result = linkify("https://start.com is the link");
+    expect(result).toEqual([
+      { type: "link", value: "https://start.com" },
+      { type: "text", value: " is the link" },
+    ]);
+  });
+
+  it("handles URLs with paths, query strings, and fragments", () => {
+    const result = linkify("link: https://example.com/path?q=1&b=2#section");
+    expect(result).toEqual([
+      { type: "text", value: "link: " },
+      { type: "link", value: "https://example.com/path?q=1&b=2#section" },
+    ]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(linkify("")).toEqual([]);
+  });
+
+  it("does not match URLs without protocol", () => {
+    const result = linkify("visit example.com today");
+    expect(result).toEqual([{ type: "text", value: "visit example.com today" }]);
+  });
+});

--- a/supabase/004_breadcrumbs.sql
+++ b/supabase/004_breadcrumbs.sql
@@ -1,0 +1,23 @@
+-- Breadcrumbs: quick-capture trail for scattered conversations
+CREATE TABLE breadcrumbs (
+  id         UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id    UUID REFERENCES auth.users(id) NOT NULL,
+  note       TEXT NOT NULL,
+  who        TEXT,          -- person(s) involved, e.g. "@alice, @bob"
+  source     TEXT,          -- where it happened, e.g. "mattermost #backend"
+  source_url TEXT,          -- optional direct link
+  project_id UUID REFERENCES projects(id) ON DELETE SET NULL,
+  status     TEXT DEFAULT 'open' CHECK (status IN ('open', 'waiting', 'resolved')),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_breadcrumbs_user_status ON breadcrumbs (user_id, status);
+CREATE INDEX idx_breadcrumbs_project ON breadcrumbs (project_id) WHERE project_id IS NOT NULL;
+
+ALTER TABLE breadcrumbs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users manage own breadcrumbs"
+  ON breadcrumbs FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
Quick-capture trail for work conversations across Mattermost, Jira, DMs, etc. Each breadcrumb captures what was said, who said it, where, and optionally links to a Pulse project. URLs in notes render as clickable links. Status flow: open → waiting → resolved.

- New breadcrumbs table with RLS (004_breadcrumbs.sql)
- useBreadcrumbs hook with CRUD operations
- BreadcrumbForm (quick-capture), BreadcrumbCard (with linkified notes), BreadcrumbList (filterable by status + searchable)
- Breadcrumbs nav tab in App.jsx + project-linked crumbs in Detail view
- linkify utility for auto-linking URLs in note text
- 29 new tests (hook: 6, components: 15, linkify: 8), all 67 pass

Closes #16