### PR TITLE
fix: add cursor-pointer to nav tabs, align Save button color

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -510,7 +510,7 @@ export default function App() {
                   key={v}
                   type="button"
                   onClick={() => setView(v)}
-                  className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  className={`flex-1 px-4 py-2 rounded-lg text-sm font-medium transition-colors cursor-pointer ${
                     view === v
                       ? "bg-slate-700 text-white"
                       : "text-slate-400 hover:text-slate-200"

--- a/src/components/Breadcrumbs.jsx
+++ b/src/components/Breadcrumbs.jsx
@@ -42,7 +42,7 @@ export function BreadcrumbForm({ onCreate, projects }) {
         />
         <button
           type="submit"
-          className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 text-white font-medium rounded-lg transition-colors"
+          className="px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white font-medium rounded-lg transition-colors cursor-pointer"
         >
           Save
         </button>


### PR DESCRIPTION
Nav tab buttons now show pointer cursor on hover. Save button changed from sky-600 to blue-600 to match the New button.