### PR TITLE
Track total repository issues separately from assigned issues

### DIFF
--- a/netlify/functions/sync-github-activity.mjs
+++ b/netlify/functions/sync-github-activity.mjs
@@ -105,11 +105,12 @@ export default async (request) => {
     const base = `https://api.github.com/repos/${r.owner}/${r.repo}`;
 
     try {
-      // Fetch in parallel: open PRs, assigned issues, latest commit
-      const [prs, issues, commits] = await Promise.all([
+      // Fetch in parallel: open PRs, assigned issues, latest commit, repo metadata
+      const [prs, issues, commits, repoMeta] = await Promise.all([
         ghFetch(`${base}/pulls?state=open&per_page=100`),
         ghFetch(`${base}/issues?assignee=${ghUsername}&state=open&per_page=100`),
         ghFetch(`${base}/commits?per_page=1`),
+        ghFetch(base), // GET /repos/{owner}/{repo} → open_issues_count
       ]);
 
       const openPrs = Array.isArray(prs) ? prs.length : 0;
@@ -119,6 +120,11 @@ export default async (request) => {
           ).length
         : 0;
       const assignedIssues = Array.isArray(issues) ? issues.length : 0;
+      // GitHub's open_issues_count includes PRs, so subtract to get issues-only.
+      // Use != null so a legitimate 0 isn't treated as missing.
+      const totalIssues = repoMeta?.open_issues_count != null
+        ? Math.max(0, repoMeta.open_issues_count - openPrs)
+        : 0;
       const latestCommit = Array.isArray(commits) && commits[0]
         ? {
             at: commits[0].commit?.committer?.date || null,
@@ -140,6 +146,7 @@ export default async (request) => {
           open_prs: openPrs,
           review_requested_prs: reviewRequested,
           assigned_issues: assignedIssues,
+          total_issues: totalIssues,
           latest_commit_at: latestCommit.at,
           latest_commit_message: latestCommit.message,
           synced_at: new Date().toISOString(),
@@ -155,6 +162,7 @@ export default async (request) => {
           openPrs,
           reviewRequested,
           assignedIssues,
+          totalIssues,
         });
       }
     } catch (err) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,6 +72,23 @@ function DeployBadge({ netlify }) {
   return <span className={`inline-flex items-center gap-1.5 text-xs font-medium ${ds.color}`}><span className={`inline-block w-2 h-2 rounded-full ${ds.dot}`} aria-hidden="true" />{ds.label}</span>;
 }
 
+function GitHubBadge({ github }) {
+  if (!github?.activity) { return null; }
+  const { openPrs, totalIssues } = github.activity;
+  if (openPrs === 0 && totalIssues === 0) { return null; }
+
+  const parts = [];
+  if (openPrs > 0) { parts.push(`${openPrs} PR${openPrs !== 1 ? "s" : ""}`); }
+  if (totalIssues > 0) { parts.push(`${totalIssues} issue${totalIssues !== 1 ? "s" : ""}`); }
+
+  return (
+    <span className="inline-flex items-center gap-1 text-xs text-slate-400">
+      <IconGithub size={11} />
+      {parts.join(" · ")}
+    </span>
+  );
+}
+
 /* ─── deploy card ────────────────────────────────────────── */
 function DeployCard({ netlify, onEdit, onRemove, onSync, syncing }) {
   if (!netlify) {
@@ -268,8 +285,11 @@ function GitHubCard({ github, onEdit, onRemove, onSync, syncing }) {
                 <p className="text-xs text-slate-500">Review</p>
               </div>
               <div className="rounded-lg bg-slate-900/50 border border-slate-700/50 p-2 text-center">
-                <p className={`text-lg font-bold ${a.assignedIssues > 0 ? "text-red-400" : "text-slate-400"}`}>{a.assignedIssues}</p>
+                <p className={`text-lg font-bold ${a.totalIssues > 0 ? "text-red-400" : "text-slate-400"}`}>{a.totalIssues}</p>
                 <p className="text-xs text-slate-500">Issues</p>
+                {a.assignedIssues > 0 && (
+                  <p className="text-xs text-slate-600 leading-tight">{a.assignedIssues} assigned</p>
+                )}
               </div>
             </div>
             {a.latestCommitMessage && (
@@ -344,7 +364,7 @@ function ProjList({ projects, onSelect }) {
                 {p.nextStep && <p className="mt-2 text-sm text-slate-500"><span className="text-slate-400 font-medium">Next:</span> {p.nextStep}</p>}
               </div>
               <div className="flex flex-col items-end gap-1.5 shrink-0">
-                <StatusBadge status={p.status} /><DeployBadge netlify={p.netlify} /><Stale updatedAt={p.updatedAt} />
+                <StatusBadge status={p.status} /><DeployBadge netlify={p.netlify} /><GitHubBadge github={p.github} /><Stale updatedAt={p.updatedAt} />
                 {total > 0 && <span className="text-xs text-slate-500">{done}/{total} tasks</span>}
               </div>
             </div>

--- a/src/hooks/useProjects.js
+++ b/src/hooks/useProjects.js
@@ -452,6 +452,7 @@ function normalizeProject(row) {
             openPrs: activity.open_prs,
             reviewRequestedPrs: activity.review_requested_prs,
             assignedIssues: activity.assigned_issues,
+            totalIssues: activity.total_issues ?? 0,
             latestCommitAt: activity.latest_commit_at,
             latestCommitMessage: activity.latest_commit_message,
             syncedAt: activity.synced_at,

--- a/supabase/005_github_total_issues.sql
+++ b/supabase/005_github_total_issues.sql
@@ -1,0 +1,7 @@
+-- ============================================================
+-- Project Pulse — Add total_issues to github_activity
+-- Run this in the Supabase SQL Editor (Dashboard > SQL Editor)
+-- ============================================================
+
+alter table public.github_activity
+  add column if not exists total_issues integer not null default 0;


### PR DESCRIPTION
## Summary
This PR enhances GitHub activity tracking to distinguish between total open issues in a repository and issues assigned to the current user. This provides better visibility into overall project health while maintaining the existing assigned issues metric.

## Key Changes

- **New `GitHubBadge` component** in `src/App.jsx`: Displays a compact badge showing open PRs and total issues count in the project list view
- **Enhanced GitHub activity data model**: 
  - Added `total_issues` field to track all open issues in a repository (calculated as `open_issues_count - openPrs` to exclude pull requests)
  - Maintained `assignedIssues` for user-specific issue tracking
  - Updated `GitHubCard` to display total issues prominently with assigned issues shown as a secondary detail
- **Backend sync improvements** in `netlify/functions/sync-github-activity.mjs`:
  - Added repository metadata fetch to retrieve `open_issues_count` from GitHub API
  - Implemented logic to calculate true issue count by subtracting PRs from the total
- **Database schema** (`supabase/005_github_total_issues.sql`): Added `total_issues` column to `github_activity` table
- **Data normalization** in `src/hooks/useProjects.js`: Updated to map `total_issues` from database records

## Implementation Details

- The `total_issues` calculation accounts for GitHub's API behavior where `open_issues_count` includes both issues and pull requests
- The `GitHubBadge` only renders when there are open PRs or issues, keeping the UI clean
- Assigned issues are now displayed as a secondary metric ("X assigned") below the total issues count in the GitHub card
- All changes maintain backward compatibility with existing data structures

https://claude.ai/code/session_018XmdEbZKHQrqjYiRnfF4SN