### PR TITLE
Fix native date input icon on dark UI

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,1 +1,9 @@
 @import "tailwindcss";
+
+:root {
+  color-scheme: dark;
+}
+
+input[type="date"]::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+}


### PR DESCRIPTION
## Summary

- Set the app-wide color scheme to dark at :root.
- Keep the WebKit native date picker indicator visible on dark inputs.

## Validation

- pnpm test
- npm run build