### PR TITLE
fix: clarify todo card status transitions and action buttons

### DIFF
--- a/src/components/TodoCard.jsx
+++ b/src/components/TodoCard.jsx
@@ -85,22 +85,31 @@ export function TodoCard({ todo, onUpdate, onDelete, projectName }) {
 
       <div className="flex items-center gap-2">
         <span className="text-xs text-slate-500">Move to:</span>
-        {status !== "open" && (
+        {status === "resolved" && (
           <button
             type="button"
             onClick={() => onUpdate(id, { status: "open" })}
             className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-sky-500 hover:text-sky-300 transition-colors"
           >
-            Open
+            Reopen
           </button>
         )}
-        {status !== "waiting" && (
+        {status !== "resolved" && status !== "waiting" && (
           <button
             type="button"
             onClick={() => onUpdate(id, { status: "waiting" })}
             className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-amber-500 hover:text-amber-300 transition-colors"
           >
             Waiting
+          </button>
+        )}
+        {status !== "resolved" && status !== "open" && (
+          <button
+            type="button"
+            onClick={() => onUpdate(id, { status: "open" })}
+            className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-sky-500 hover:text-sky-300 transition-colors"
+          >
+            Unblock
           </button>
         )}
         {status !== "resolved" && (

--- a/src/components/TodoCard.jsx
+++ b/src/components/TodoCard.jsx
@@ -13,6 +13,15 @@ const STATUS_LABELS = {
   resolved: "done",
 };
 
+// Valid transitions per status: [targetStatus, label, hoverColour]
+const TRANSITIONS = {
+  open:     [["waiting", "Waiting",   "hover:border-amber-500 hover:text-amber-300"],
+             ["resolved", "Mark done", "hover:border-emerald-500 hover:text-emerald-300"]],
+  waiting:  [["open",     "Unblock",   "hover:border-sky-500 hover:text-sky-300"],
+             ["resolved", "Mark done", "hover:border-emerald-500 hover:text-emerald-300"]],
+  resolved: [["open",     "Reopen",    "hover:border-sky-500 hover:text-sky-300"]],
+};
+
 const DUE_STYLES = {
   today: "bg-yellow-950/40 border-yellow-600/70",
   late: "bg-red-950/40 border-red-600/70",
@@ -85,42 +94,16 @@ export function TodoCard({ todo, onUpdate, onDelete, projectName }) {
 
       <div className="flex items-center gap-2">
         <span className="text-xs text-slate-500">Move to:</span>
-        {status === "resolved" && (
+        {TRANSITIONS[status].map(([target, label, hover]) => (
           <button
+            key={target}
             type="button"
-            onClick={() => onUpdate(id, { status: "open" })}
-            className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-sky-500 hover:text-sky-300 transition-colors"
+            onClick={() => onUpdate(id, { status: target })}
+            className={`text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 transition-colors ${hover}`}
           >
-            Reopen
+            {label}
           </button>
-        )}
-        {status !== "resolved" && status !== "waiting" && (
-          <button
-            type="button"
-            onClick={() => onUpdate(id, { status: "waiting" })}
-            className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-amber-500 hover:text-amber-300 transition-colors"
-          >
-            Waiting
-          </button>
-        )}
-        {status !== "resolved" && status !== "open" && (
-          <button
-            type="button"
-            onClick={() => onUpdate(id, { status: "open" })}
-            className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-sky-500 hover:text-sky-300 transition-colors"
-          >
-            Unblock
-          </button>
-        )}
-        {status !== "resolved" && (
-          <button
-            type="button"
-            onClick={() => onUpdate(id, { status: "resolved" })}
-            className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-emerald-500 hover:text-emerald-300 transition-colors"
-          >
-            Mark done
-          </button>
-        )}
+        ))}
         <button
           type="button"
           onClick={() => onDelete(id)}

--- a/src/components/TodoCard.jsx
+++ b/src/components/TodoCard.jsx
@@ -83,12 +83,13 @@ export function TodoCard({ todo, onUpdate, onDelete, projectName }) {
         <span>{timeAgo(createdAt)}</span>
       </div>
 
-      <div className="flex gap-2">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-slate-500">Move to:</span>
         {status !== "open" && (
           <button
             type="button"
             onClick={() => onUpdate(id, { status: "open" })}
-            className="text-xs text-slate-400 hover:text-sky-300 transition-colors"
+            className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-sky-500 hover:text-sky-300 transition-colors"
           >
             Open
           </button>
@@ -97,7 +98,7 @@ export function TodoCard({ todo, onUpdate, onDelete, projectName }) {
           <button
             type="button"
             onClick={() => onUpdate(id, { status: "waiting" })}
-            className="text-xs text-slate-400 hover:text-amber-300 transition-colors"
+            className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-amber-500 hover:text-amber-300 transition-colors"
           >
             Waiting
           </button>
@@ -106,7 +107,7 @@ export function TodoCard({ todo, onUpdate, onDelete, projectName }) {
           <button
             type="button"
             onClick={() => onUpdate(id, { status: "resolved" })}
-            className="text-xs text-slate-400 hover:text-emerald-300 transition-colors"
+            className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-emerald-500 hover:text-emerald-300 transition-colors"
           >
             Mark done
           </button>
@@ -114,7 +115,7 @@ export function TodoCard({ todo, onUpdate, onDelete, projectName }) {
         <button
           type="button"
           onClick={() => onDelete(id)}
-          className="text-xs text-slate-400 hover:text-red-400 transition-colors ml-auto"
+          className="text-xs px-2 py-0.5 rounded border border-slate-600 text-slate-400 hover:border-red-500 hover:text-red-400 transition-colors ml-auto"
         >
           Delete
         </button>

--- a/src/components/TodoCard.jsx
+++ b/src/components/TodoCard.jsx
@@ -94,7 +94,7 @@ export function TodoCard({ todo, onUpdate, onDelete, projectName }) {
 
       <div className="flex items-center gap-2">
         <span className="text-xs text-slate-500">Move to:</span>
-        {TRANSITIONS[status].map(([target, label, hover]) => (
+        {(TRANSITIONS[status] ?? []).map(([target, label, hover]) => (
           <button
             key={target}
             type="button"


### PR DESCRIPTION
## What changed

Three commits that together fix the confusing action buttons on todo cards.

### 1. Visual disambiguation (fixes #43)
Action buttons in the card footer were bare text, indistinguishable from status labels. Added a `Move to:` prefix label and gave each button a visible border with colour-matched hover states so they read as interactive controls.

### 2. Correct transitions and labels
- **`done` cards** previously showed `Open` and `Waiting` — neither made sense. A resolved card can only be reopened, so it now shows a single `Reopen` button.
- **`waiting` cards** showed `Open` which was ambiguous. Renamed to `Unblock` to reflect the actual intent (the blocker has been cleared).
- Removed the `done → waiting` transition entirely — it had no logical meaning.

Transition table after this PR:
| State | Actions |
|---|---|
| `open` | Waiting · Mark done |
| `waiting` | Unblock · Mark done |
| `resolved` | Reopen |

### 3. Refactor: transitions map
Replaced the chain of per-status conditionals in JSX with a `TRANSITIONS` lookup table mapping each status to its valid `[targetStatus, label, hoverColour]` tuples. The JSX now just `.map()`s over the entries — adding or changing a transition is a single-line edit to `TRANSITIONS`.

## Testing
All 70 existing tests pass. No test changes were required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned the todo card status management interface with a "Move to:" section that dynamically displays available status transitions based on the current todo state. This replaces the previous layout of separate status buttons with a more organized, contextually-aware approach to updating todo items.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/schalkneethling/project-pulse/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->