### PR TITLE
Add horizontal swim-lane layout option for Kanban TODOs

### DIFF
--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -62,7 +62,6 @@ export function TodoBoard({ todos, onUpdate, onDelete, projects }) {
 
   const renderCard = (todo) => (
     <TodoCard
-      key={todo.id}
       todo={todo}
       onUpdate={onUpdate}
       onDelete={onDelete}
@@ -135,7 +134,7 @@ export function TodoBoard({ todos, onUpdate, onDelete, projects }) {
                       Drop todos here
                     </p>
                   ) : (
-                    items.map(renderCard)
+                    items.map((todo) => <div key={todo.id}>{renderCard(todo)}</div>)
                   )}
                 </div>
               </section>

--- a/src/components/TodoBoard.jsx
+++ b/src/components/TodoBoard.jsx
@@ -10,12 +10,20 @@ const COLUMN_TINT = {
   done: "border-emerald-700/40",
 };
 
+const LAYOUTS = [
+  ["columns", "Columns"],
+  ["lanes", "Lanes"],
+];
+
 export function TodoBoard({ todos, onUpdate, onDelete, projects }) {
   const [search, setSearch] = useState("");
   const [editing, setEditing] = useState(null);
   const [dragOver, setDragOver] = useState(null);
+  const [layout, setLayout] = useState("columns");
 
-  const projectMap = Object.fromEntries((projects || []).map((p) => [p.id, p.name || "Untitled"]));
+  const projectMap = Object.fromEntries(
+    (projects || []).map((p) => [p.id, p.name || "Untitled"]),
+  );
 
   const q = search.trim().toLowerCase();
   const filtered = q
@@ -24,9 +32,9 @@ export function TodoBoard({ todos, onUpdate, onDelete, projects }) {
       )
     : todos;
 
-  const columns = Object.fromEntries(STATUS_ORDER.map((s) => [s, []]));
+  const lanes = Object.fromEntries(STATUS_ORDER.map((s) => [s, []]));
   for (const t of filtered) {
-    (columns[t.status] || columns.backlog).push(t);
+    (lanes[t.status] || lanes.backlog).push(t);
   }
 
   const handleDrop = (e, status) => {
@@ -40,9 +48,34 @@ export function TodoBoard({ todos, onUpdate, onDelete, projects }) {
     }
   };
 
+  const dragHandlers = (status) => ({
+    onDragOver: (e) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      if (dragOver !== status) setDragOver(status);
+    },
+    onDragLeave: () => {
+      if (dragOver === status) setDragOver(null);
+    },
+    onDrop: (e) => handleDrop(e, status),
+  });
+
+  const renderCard = (todo) => (
+    <TodoCard
+      key={todo.id}
+      todo={todo}
+      onUpdate={onUpdate}
+      onDelete={onDelete}
+      onEdit={setEditing}
+      projectName={todo.projectId ? projectMap[todo.projectId] : null}
+      draggable
+      compact
+    />
+  );
+
   return (
     <div className="space-y-4">
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <label htmlFor="todo-search" className="sr-only">
           Search todos
         </label>
@@ -55,57 +88,107 @@ export function TodoBoard({ todos, onUpdate, onDelete, projects }) {
           aria-label="Search todos"
           className="flex-1 max-w-md bg-slate-800 border border-slate-700 rounded-lg px-4 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-sky-500/50"
         />
+        <div
+          role="group"
+          aria-label="Board layout"
+          className="inline-flex rounded-lg border border-slate-700 bg-slate-800 p-0.5 text-xs"
+        >
+          {LAYOUTS.map(([value, label]) => (
+            <button
+              key={value}
+              type="button"
+              onClick={() => setLayout(value)}
+              aria-pressed={layout === value}
+              className={`px-3 py-1 rounded-md transition-colors ${
+                layout === value
+                  ? "bg-slate-700 text-white"
+                  : "text-slate-400 hover:text-slate-200"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
         <span className="text-xs text-slate-500">{filtered.length} todos</span>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4">
-        {STATUS_ORDER.map((status) => {
-          const items = columns[status];
-          const meta = STATUS_META[status];
-          const isOver = dragOver === status;
-          return (
-            <section
-              key={status}
-              onDragOver={(e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                if (dragOver !== status) setDragOver(status);
-              }}
-              onDragLeave={() => {
-                if (dragOver === status) setDragOver(null);
-              }}
-              onDrop={(e) => handleDrop(e, status)}
-              className={`rounded-xl border ${COLUMN_TINT[status]} bg-slate-900/40 p-3 min-h-[60vh] transition-colors ${isOver ? "ring-2 ring-sky-500/60 bg-slate-900/70" : ""}`}
-              aria-label={`${meta.label} column`}
-            >
-              <header className="flex items-center justify-between mb-3 px-1">
-                <h3 className="text-sm font-semibold text-slate-200">{meta.label}</h3>
-                <span className="text-xs text-slate-500">{items.length}</span>
-              </header>
-              <div className="space-y-3">
+      {layout === "columns" ? (
+        <div className="grid gap-4 max-md:grid-cols-1 md:max-xl:grid-cols-2 xl:grid-cols-5">
+          {STATUS_ORDER.map((status) => {
+            const items = lanes[status];
+            const meta = STATUS_META[status];
+            const isOver = dragOver === status;
+            return (
+              <section
+                key={status}
+                {...dragHandlers(status)}
+                className={`rounded-xl border ${COLUMN_TINT[status]} bg-slate-900/40 p-3 min-h-[60vh] transition-colors ${isOver ? "ring-2 ring-sky-500/60 bg-slate-900/70" : ""}`}
+                aria-label={`${meta.label} column`}
+              >
+                <header className="flex items-center justify-between mb-3 px-1">
+                  <h3 className="text-sm font-semibold text-slate-200">{meta.label}</h3>
+                  <span className="text-xs text-slate-500">{items.length}</span>
+                </header>
+                <div className="space-y-3">
+                  {items.length === 0 ? (
+                    <p className="text-xs text-slate-600 text-center py-6 border border-dashed border-slate-800 rounded-lg">
+                      Drop todos here
+                    </p>
+                  ) : (
+                    items.map(renderCard)
+                  )}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          {STATUS_ORDER.map((status) => {
+            const items = lanes[status];
+            const meta = STATUS_META[status];
+            const isOver = dragOver === status;
+            return (
+              <section
+                key={status}
+                {...dragHandlers(status)}
+                className={`rounded-xl border ${COLUMN_TINT[status]} bg-slate-900/40 transition-colors ${isOver ? "ring-2 ring-sky-500/60 bg-slate-900/70" : ""}`}
+                aria-label={`${meta.label} lane`}
+              >
+                <header className="sticky top-0 z-10 flex items-center justify-between gap-3 px-4 py-2 bg-slate-900/90 backdrop-blur rounded-t-xl border-b border-slate-800">
+                  <h3 className="text-sm font-semibold text-slate-200">{meta.label}</h3>
+                  <span className="text-xs text-slate-500">{items.length}</span>
+                </header>
                 {items.length === 0 ? (
-                  <p className="text-xs text-slate-600 text-center py-6 border border-dashed border-slate-800 rounded-lg">
+                  <p className="text-xs text-slate-600 text-center py-6 mx-3 my-3 border border-dashed border-slate-800 rounded-lg">
                     Drop todos here
                   </p>
                 ) : (
-                  items.map((todo) => (
-                    <TodoCard
-                      key={todo.id}
-                      todo={todo}
-                      onUpdate={onUpdate}
-                      onDelete={onDelete}
-                      onEdit={setEditing}
-                      projectName={todo.projectId ? projectMap[todo.projectId] : null}
-                      draggable
-                      compact
-                    />
-                  ))
+                  <div
+                    className="flex items-stretch gap-3 overflow-x-auto p-3 snap-x snap-mandatory"
+                    style={{ scrollbarColor: "rgb(51 65 85) transparent" }}
+                  >
+                    <span
+                      className={`sticky left-0 z-[1] self-center shrink-0 text-[10px] font-medium uppercase tracking-wider px-2 py-1 rounded-full ${meta.pill}`}
+                      aria-hidden="true"
+                    >
+                      {meta.label}
+                    </span>
+                    {items.map((todo) => (
+                      <div
+                        key={todo.id}
+                        className="snap-start shrink-0 max-sm:w-72 sm:w-80"
+                      >
+                        {renderCard(todo)}
+                      </div>
+                    ))}
+                  </div>
                 )}
-              </div>
-            </section>
-          );
-        })}
-      </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
 
       {editing && (
         <TodoEditModal


### PR DESCRIPTION
Closes #58.

## Summary
Adds a **Columns / Lanes** layout toggle on the TODO board so the horizontal swim-lane layout proposed in the issue can be prototyped alongside the existing vertical-column Kanban. Defaults to **Columns** — no behavior change unless you flip the toggle.

## Lanes layout
- One horizontal lane per status, stacked vertically with consistent flex `gap`.
- Lane header is `position: sticky; top: 0` — stays in view as the page scrolls.
- Cards inside a lane scroll horizontally with `snap-x snap-mandatory` and `snap-start` per card.
- A status pill inside each lane is `position: sticky; left: 0` — stays pinned as you scroll the lane horizontally. This is the dual-axis sticky idea from the issue: each element is sticky on its own axis because the lane header and the in-lane marker live in different scroll containers (page vs. lane), so standard `position: sticky` already produces single-axis behavior — no per-axis sticky shim needed yet.
- Drag-and-drop between lanes shares the same handlers as the columns layout via a `dragHandlers` factory.

## Shared First CSS
While refactoring this area I converted the viewport-specific Tailwind utilities to **Shared First** using Tailwind v4's bounded `min-*`/`max-*` variants. Each breakpoint is now self-contained — no struck-through overrides in DevTools.

| Element | Small | Medium | Large |
|---|---|---|---|
| Columns grid | `max-md:grid-cols-1` | `md:max-xl:grid-cols-2` | `xl:grid-cols-5` |
| Lane card width | `max-sm:w-72` | `sm:w-80` | `sm:w-80` |

## Test plan
- [ ] Open the TODOs view, confirm Columns layout renders unchanged.
- [ ] Toggle to **Lanes**, confirm one lane per status stacked vertically.
- [ ] Scroll the page — lane header should stick to the top of the viewport.
- [ ] Scroll a lane horizontally — the status pill on the left should stay pinned while cards scroll past.
- [ ] Drag a card from one lane to another in Lanes layout; confirm status updates.
- [ ] Resize through sm / md / xl breakpoints in both layouts; confirm no cascade overrides in DevTools.
- [x] `pnpm test` (70/70 pass)
- [x] `pnpm build` (clean)

## Note
I did not visually verify in a running browser — flipping to Lanes in the live app is the main thing a reviewer should check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Board layout switcher: toggle between "columns" and a new "lanes" view to organize tasks.
  * Lanes view: sticky lane headers with horizontally scrollable rows and per-lane labels for easier navigation.
  * Consistent drag-and-drop behavior across both layouts for moving tasks.
  * Todo count display on the board for a quick overview.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->