### PR TITLE
Fix stale badge to reflect GitHub and deploy activity

### DIFF
--- a/src/components/Overview.jsx
+++ b/src/components/Overview.jsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { daysSince } from "../lib/helpers";
+import { daysSince, lastActivityAt } from "../lib/helpers";
 import { getDueState, formatDateKey } from "../lib/dueDate";
 import { DEPLOY_STATUS } from "../lib/constants";
 import { visibleProjects, archivedProjects, activeWorkItems } from "../lib/workItems";
@@ -37,7 +37,9 @@ export function Overview({
 
   const active = visible.filter((p) => p.status === "active");
   const blocked = visible.filter((p) => p.status === "blocked");
-  const stale = visible.filter((p) => p.status === "active" && daysSince(p.updatedAt) >= 7);
+  const stale = visible.filter(
+    (p) => p.status === "active" && daysSince(lastActivityAt(p)) >= 7,
+  );
 
   const tasksWithProject = visible.flatMap((p) =>
     activeWorkItems(p.tasks).map((t) => ({ ...t, pName: p.name, pId: p.id })),
@@ -54,12 +56,7 @@ export function Overview({
   });
   const reviewPRs = visible.filter((p) => p.github?.activity?.reviewRequestedPrs > 0);
   const assignedIssues = visible.filter((p) => p.github?.activity?.assignedIssues > 0);
-  const ghStale = visible.filter((p) => {
-    if (!p.github?.activity?.latestCommitAt || p.status !== "active") return false;
-    return daysSince(p.github.activity.latestCommitAt) >= 7;
-  });
-
-  const staleProjects = [...new Map([...stale, ...ghStale].map((p) => [p.id, p])).values()];
+  const staleProjects = stale;
 
   const dueSoon = tasksWithProject
     .filter((t) => isDueSoonTask(t))
@@ -300,7 +297,7 @@ export function Overview({
                   <span className="font-medium text-slate-200">{p.name}</span>
                   <div className="flex items-center gap-2 shrink-0">
                     <StatusBadge status={p.status} />
-                    <Stale updatedAt={p.updatedAt} />
+                    <Stale project={p} />
                   </div>
                 </div>
                 <p className="mt-1 text-sm text-slate-400">{p.nextStep}</p>
@@ -358,7 +355,7 @@ export function Overview({
               >
                 <div className="flex items-center justify-between gap-2">
                   <span className="font-medium text-slate-200">{p.name}</span>
-                  <Stale updatedAt={p.updatedAt} />
+                  <Stale project={p} />
                 </div>
                 {p.nextStep && <p className="mt-1 text-sm text-slate-400">Next: {p.nextStep}</p>}
               </button>

--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -50,7 +50,7 @@ export function ProjectList({ projects, onSelect }) {
                 )}
                 <DeployBadge netlify={p.netlify} />
                 <GitHubBadge github={p.github} />
-                {!isArchived && <Stale updatedAt={p.updatedAt} />}
+                {!isArchived && <Stale project={p} />}
                 {total > 0 && (
                   <span className="text-xs text-slate-500">
                     {done}/{total} done

--- a/src/components/ui/ProjectBadges.jsx
+++ b/src/components/ui/ProjectBadges.jsx
@@ -1,4 +1,4 @@
-import { daysSince, fmtDate } from "../../lib/helpers";
+import { daysSince, fmtDate, lastActivityAt } from "../../lib/helpers";
 import { STATUS, DEPLOY_STATUS } from "../../lib/constants";
 import { IconClock, IconGithub } from "../icons";
 
@@ -12,14 +12,15 @@ export function StatusBadge({ status }) {
   );
 }
 
-export function Stale({ updatedAt }) {
-  const days = daysSince(updatedAt);
+export function Stale({ project }) {
+  const activityAt = lastActivityAt(project);
+  const days = daysSince(activityAt);
   if (days === null || days < 7) return null;
   const label = days >= 30 ? `${Math.floor(days / 30)}mo stale` : `${days}d stale`;
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs ${days >= 14 ? "text-red-400" : "text-amber-400"}`}
-      title={`Last updated ${fmtDate(updatedAt)}`}
+      title={`Last activity ${fmtDate(activityAt)}`}
     >
       <IconClock size={12} />
       {label}

--- a/src/hooks/useProjects.js
+++ b/src/hooks/useProjects.js
@@ -99,6 +99,11 @@ export function useProjects(userId) {
     if ("sortOrder" in dbFields) payload.sort_order = dbFields.sortOrder;
     if ("archivedAt" in dbFields) payload.archived_at = dbFields.archivedAt;
 
+    if (Object.keys(payload).length === 0) return;
+
+    const now = new Date().toISOString();
+    payload.updated_at = now;
+
     const { error } = await supabase.from("projects").update(payload).eq("id", id);
 
     if (error) {
@@ -107,9 +112,7 @@ export function useProjects(userId) {
     }
 
     setProjects((prev) =>
-      prev.map((p) =>
-        p.id === id ? { ...p, ...dbFields, updatedAt: new Date().toISOString() } : p,
-      ),
+      prev.map((p) => (p.id === id ? { ...p, ...dbFields, updatedAt: now } : p)),
     );
   }, []);
 

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -7,6 +7,22 @@ const LOCALE = navigator?.languages?.[0] ?? "en-ZA";
 export const daysSince = (d) =>
   d ? Math.floor((Date.now() - new Date(d).getTime()) / 86400000) : null;
 
+/** Latest activity across in-app edits, GitHub commits, and Netlify deploys. */
+export function lastActivityAt(project) {
+  const candidates = [
+    project?.updatedAt,
+    project?.github?.activity?.latestCommitAt,
+    project?.netlify?.lastDeploy?.publishedAt,
+    project?.netlify?.lastDeploy?.createdAt,
+  ].filter(Boolean);
+
+  if (candidates.length === 0) return null;
+
+  return candidates.reduce((latest, d) =>
+    new Date(d).getTime() > new Date(latest).getTime() ? d : latest,
+  );
+}
+
 export const fmtDate = (d) =>
   d
     ? new Date(d).toLocaleDateString(LOCALE, {

--- a/src/lib/helpers.test.js
+++ b/src/lib/helpers.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { daysSince, fmtDate, fmtDuration, timeAgo } from "./helpers";
+import { daysSince, fmtDate, fmtDuration, timeAgo, lastActivityAt } from "./helpers";
 
 describe("daysSince", () => {
   afterEach(() => vi.useRealTimers());
@@ -21,6 +21,26 @@ describe("daysSince", () => {
     expect(daysSince("2026-04-04T12:00:00Z")).toBe(1);
     expect(daysSince("2026-03-29T12:00:00Z")).toBe(7);
     expect(daysSince("2026-03-06T12:00:00Z")).toBe(30);
+  });
+});
+
+describe("lastActivityAt", () => {
+  it("returns null when no activity dates exist", () => {
+    expect(lastActivityAt({})).toBeNull();
+    expect(lastActivityAt(null)).toBeNull();
+  });
+
+  it("returns the most recent date across sources", () => {
+    const project = {
+      updatedAt: "2026-01-01T00:00:00Z",
+      github: { activity: { latestCommitAt: "2026-06-12T10:00:00Z" } },
+      netlify: { lastDeploy: { publishedAt: "2026-03-01T00:00:00Z" } },
+    };
+    expect(lastActivityAt(project)).toBe("2026-06-12T10:00:00Z");
+  });
+
+  it("falls back to updatedAt when no integrations are linked", () => {
+    expect(lastActivityAt({ updatedAt: "2026-04-01T00:00:00Z" })).toBe("2026-04-01T00:00:00Z");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `lastActivityAt()` to use the most recent in-app edit, GitHub commit, or Netlify deploy when calculating staleness
- Update the stale badge and overview "Needs a Nudge" section to use combined activity instead of only `project.updatedAt`
- Persist `updated_at` when editing project fields so in-app changes survive refresh

## Test plan
- [ ] Link a GitHub repo with recent commits and confirm the stale badge is hidden on the overview and project list
- [ ] Edit a project's next step and refresh the page; confirm the updated timestamp is preserved
- [ ] Verify a project with no activity in 7+ days still shows the stale badge
- [ ] Run `npm test -- --run src/lib/helpers.test.js`


Made with [Cursor](https://cursor.com)